### PR TITLE
Add the ability for platforms to define a custom render macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ defmodule LiveViewNativeExamplePlatform.Platform do
     def context(struct) do
       LiveViewNativePlatform.Context.define(:my_platform, # The unique `platform_id`
         custom_modifiers: struct.custom_modifiers, # Can be omitted if custom modifiers should not be supported
+        render_macro: :sigil_MYP, # Optional, if blank templates can only be rendered using `~LVN` sigil with `platform_id` modifier
         tag_handler: LiveViewNativeExamplePlatform.TagEngine, # Optional, defaults to `LiveViewNative.TagEngine`
         template_extension: ".myp.heex", # Optional, defaults to ".#{platform_id}.heex"
         otp_app: :live_view_native_example_platform # The OTP app name of your platform library

--- a/lib/live_view_native_platform/context.ex
+++ b/lib/live_view_native_platform/context.ex
@@ -7,6 +7,7 @@ defmodule LiveViewNativePlatform.Context do
             platform_config: nil,
             platform_id: nil,
             platform_modifiers: [],
+            render_macro: nil,
             tag_handler: LiveViewNative.TagEngine,
             template_extension: nil,
             template_namespace: nil
@@ -21,7 +22,8 @@ defmodule LiveViewNativePlatform.Context do
 
   def define(platform_id, opts \\ []) do
     otp_app = Keyword.fetch!(opts, :otp_app)
-    temolate_extension = Keyword.get(opts, :template_extension, ".#{platform_id}.heex")
+    render_macro = Keyword.get(opts, :render_macro)
+    template_extension = Keyword.get(opts, :template_extension, ".#{platform_id}.heex")
 
     with spec <- Application.spec(otp_app),
          modules <- spec[:modules] || [],
@@ -34,9 +36,10 @@ defmodule LiveViewNativePlatform.Context do
         modifiers: modifiers_struct(modules),
         platform_id: platform_id,
         platform_modifiers: keyed_platform_modifiers,
+        render_macro: render_macro,
         tag_handler: Keyword.get(opts, :tag_handler, LiveViewNative.TagEngine),
-        template_extension: temolate_extension,
-        template_namespace: Keyword.get(opts, :template_namespace, namespace),
+        template_extension: template_extension,
+        template_namespace: Keyword.get(opts, :template_namespace, namespace)
       }
     else
       error ->


### PR DESCRIPTION
This PR adds the ability for platform libraries to define a custom render macro. This can be used to define custom sigils, like so:

```elixir
defimpl LiveViewNativePlatform do
  require Logger

  def context(struct) do
    LiveViewNativePlatform.Context.define(:swiftui,
      custom_modifiers: struct.custom_modifiers,
      render_macro: :sigil_SWIFTUI,
      otp_app: :live_view_native_swift_ui
    )
  end
  
  # ...
end
```

Which allows:

```elixir
def render(%{platform_id: :swiftui} = assigns) do
  ~SWIFTUI"""
  <VStack id="hello-ios">
    <HStack modifiers={@native |> padding(all: 5)}>
      <Text>Hello iOS!</Text>
    <Spacer />
  </VStack>
  """
end
```

Related PR: https://github.com/liveview-native/live_view_native/pull/19