### PR TITLE
Add `Addon` macro and property

### DIFF
--- a/lib/live_view_native_platform/addon.ex
+++ b/lib/live_view_native_platform/addon.ex
@@ -1,0 +1,7 @@
+defmodule LiveViewNativePlatform.Addon do
+  defmacro __using__([otp_app: otp_app]) do
+    quote do
+      def otp_app, do: unquote(otp_app)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `LiveViewNativePlatform.Addon` macro that can be used by add-on libraries. It requires the `otp_app` option:

```ex
defmodule LiveViewNativeSwiftUiCharts do
  use LiveViewNativePlatform.Addon, otp_app: :live_view_native_swift_ui_charts
end
```

Modifiers will then be automatically discovered when passed to a platform's config:

```ex
config :live_view_native, LiveViewNativeSwiftUi.Platform,
  addons: [LiveViewNativeSwiftUiCharts],
  ...
```

Any modifiers in the add-on will be merged with the `platform_modifiers`.

One issue with the current modifier discovery is ambiguity when an add-on supports multiple clients.
For example, assume we have a SwiftUI and Jetpack Compose client. We then make a cross-platform add-on library for displaying maps (for example). In this library, we have two add-on modules:

* `LiveViewNativeMaps.SwiftUI`
* `LiveViewNativeMaps.JetpackCompose`

These contain the platform-specific modifiers. However, since the modifiers are looked up based by `Application.spec`, we have no way of distinguishing which module the modifiers are under.

@supernintendo Do you have any ideas for how only modifiers in a particular module could be looked up?

Ideally we would be able to have two configs:

```ex
config :live_view_native, LiveViewNativeSwiftUi.Platform,
  addons: [LiveViewNativeMaps.SwiftUi],
  ...

config :live_view_native, LiveViewNativeJetpackCompose.Platform,
  addons: [LiveViewNativeMaps.JetpackCompose],
  ...
```

It's also possible this is not an issue, if add-ons will always either be platform specific or support all of the same modifiers with no differentiation.