### PR TITLE
Add `change_event` macro

### DIFF
--- a/lib/live_view_native_platform/modifier.ex
+++ b/lib/live_view_native_platform/modifier.ex
@@ -4,8 +4,15 @@ defmodule LiveViewNativePlatform.Modifier do
       import LiveViewNativePlatform.Modifier,
         only: [
           modifier_schema: 1,
-          modifier_schema: 2
+          modifier_schema: 2,
+          change_event: 0
         ]
+    end
+  end
+
+  defmacro change_event() do
+    quote do
+      field(:change, LiveViewNativePlatform.Modifier.Types.Event, default: nil)
     end
   end
 

--- a/lib/live_view_native_platform/modifier/types/event.ex
+++ b/lib/live_view_native_platform/modifier/types/event.ex
@@ -11,7 +11,10 @@ defmodule LiveViewNativePlatform.Modifier.Types.Event do
   def cast(value) when is_map(value) do
     value =
       value
-      |> Map.update(:params, Jason.encode!(Map.new()), fn params -> Jason.encode!(params) end)
+      |> Map.update(:params, nil, fn
+        nil -> nil
+        params -> Jason.encode!(params)
+      end)
 
     {:ok, struct(__MODULE__, value)}
   end

--- a/lib/live_view_native_platform/modifier/types/event.ex
+++ b/lib/live_view_native_platform/modifier/types/event.ex
@@ -1,0 +1,20 @@
+defmodule LiveViewNativePlatform.Modifier.Types.Event do
+  @derive Jason.Encoder
+  defstruct [:event, :type, :params, :target, :debounce, :throttle]
+
+  use LiveViewNativePlatform.Modifier.Type
+  def type, do: :map
+
+  def cast(nil), do: {:ok, nil}
+  def cast(event) when is_bitstring(event), do: {:ok, %__MODULE__{event: event}}
+
+  def cast(value) when is_map(value) do
+    value =
+      value
+      |> Map.update(:params, Jason.encode!(Map.new()), fn params -> Jason.encode!(params) end)
+
+    {:ok, struct(__MODULE__, value)}
+  end
+
+  def cast(_), do: :error
+end


### PR DESCRIPTION
This moves the `Event` type from `liveview-client-swiftui` into platform, and adds a macro that puts a `change` field on a modifier.

The `change_event` should be put on any modifier that will send `phx-change` type events. You can see this in action on modifiers here: https://github.com/liveview-native/liveview-client-swiftui/blob/4de8498d4db1cdb4046416a3b909ef5e1d77d088/lib/live_view_native_swift_ui/modifiers/search/searchable.ex#L12