### PR TITLE
Modifiers - don't cast empty strings to `nil`

### DIFF
--- a/lib/live_view_native_platform/modifier.ex
+++ b/lib/live_view_native_platform/modifier.ex
@@ -32,7 +32,7 @@ defmodule LiveViewNativePlatform.Modifier do
 
       def changeset(modifier \\ %__MODULE__{}, attrs) do
         modifier
-        |> cast(attrs, fields())
+        |> cast(attrs, fields(), empty_values: [])
       end
 
       def fields do


### PR DESCRIPTION
This PR fixes empty strings being improperly cast to `nil` in modifier schemas. Fixes #9 